### PR TITLE
[REFACTOR](imu) Improve imu_publisher stability and readibility

### DIFF
--- a/src/bero_drivers/imu/imu/imu_publisher.py
+++ b/src/bero_drivers/imu/imu/imu_publisher.py
@@ -22,18 +22,18 @@ class ImuPublisherNode(Node):
 
         # ---------------- Declare Parameter ----------------
         # EKF에서 사용되지 않는 항목이 무시되도록 1e3으로 크게 설정
-        self.declare_parameter("orientation_covariance_diagonal", [1e3, 1e3, 0.001])  # yaw만 사용
-        self.declare_parameter("angular_velocity_covariance_diagonal", [1e3, 1e3, 0.001])  # gz만 사용
-        self.declare_parameter("linear_acceleration_covariance_diagonal", [1e3, 1e3, 1e3])
+        self.declare_parameter("rpy_cov_diag", [1e3, 1e3, 0.001])  # yaw만 사용
+        self.declare_parameter("gyro_cov_diag", [1e3, 1e3, 0.001])  # gz만 사용
+        self.declare_parameter("accel_cov_diag", [1e3, 1e3, 1e3])
 
         # ---------------- Get Parameter ----------------
-        self.orientation_cov_diag = self.get_parameter("orientation_covariance_diagonal").value
-        self.ang_vel_cov_diag = self.get_parameter("angular_velocity_covariance_diagonal").value
-        self.lin_acc_cov_diag = self.get_parameter("linear_acceleration_covariance_diagonal").value
+        self.orientation_cov_diag = self.get_parameter("rpy_cov_diag").value
+        self.ang_vel_cov_diag = self.get_parameter("gyro_cov_diag").value
+        self.lin_acc_cov_diag = self.get_parameter("accel_cov_diag").value
 
         # ---------------- IMU & Publisher Initialization ----------------
         self.pub = self.create_publisher(Imu, "/imu/data", 10)
-        self.imu = popImu("can0", "500000")
+        self.imu = popImu("can0", 500000)
         self.imu.callback(self.imu_cb, repeat=1)
 
         self.get_logger().info("IMU publisher started")
@@ -113,9 +113,12 @@ def main(args=None):
     node = ImuPublisherNode()
     try:
         rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == "__main__":

--- a/src/bero_drivers/imu/setup.py
+++ b/src/bero_drivers/imu/setup.py
@@ -13,14 +13,14 @@ setup(
     ],
     install_requires=['setuptools'],
     zip_safe=True,
-    maintainer='soda',
+    maintainer='shosae',
     maintainer_email='phone13324@gmail.com',
     description='TODO: Package description',
     license='TODO: License declaration',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
-            'imu_publisher = imu.imu_publisher:main'
+            'imu_publisher = imu.imu_publisher:main',
         ],
     },
 )


### PR DESCRIPTION
## ✅ 유지 보수 및 안정성 개선

- imu/setup.py
  - maintainer를 soda에서 shosae로 변경.
  - console_scripts의 imu_publisher 항목에 trailing comma 추가

- imu/imu_publisher.py
  - 파라미터 이름을 간결하게 축약하여 가독성 향상
  - Ctrl+C 종료 시 불필요한 에러 메시지를 방지하기 위한 KeyboardInterrupt 예외 처리 추가
  - rclpy.ok() 상태를 확인한 후 rclpy.shutdown()을 호출하여 중복 종료 오류 방지