### PR TITLE
[FIX](teleop): Add missing comma in console_scripts entry

### DIFF
--- a/src/bero_teleop/setup.py
+++ b/src/bero_teleop/setup.py
@@ -20,8 +20,8 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
-            'omni_drive_ctrl = bero_teleop.omni_drive_controller:main'
-            'keyboard_ctrl = bero_teleop.keyboard_ctrl:main'
+            'omni_drive_ctrl = bero_teleop.omni_drive_controller:main',
+            'keyboard_ctrl = bero_teleop.keyboard_ctrl:main',
         ],
     },
 )


### PR DESCRIPTION
## ✅ 주요 변경 사항

- bero_teleop/setup.py
console_scripts 항목에 누락된 쉼표 추가.
trailing comma를 추가하여 이후 발생 가능한 문법 오류를 예방하고, git diff 시 변경 사항이 명확하게 표시되도록 개선함.
